### PR TITLE
Add minimum height for camera

### DIFF
--- a/Assets/Scripts/CameraScript.cs
+++ b/Assets/Scripts/CameraScript.cs
@@ -21,6 +21,8 @@ public class CameraScript : MonoBehaviour {
     private float sizeFactor;
     [SerializeField]
     private float maxChange;
+    [SerializeField]
+    private float minimumHeight;
 
     private Camera pcam;
 
@@ -136,7 +138,7 @@ public class CameraScript : MonoBehaviour {
         }
 
         // Center the Camera
-        transform.position = new Vector3(xTotal, yTotal, -10);
+        transform.position = new Vector3(xTotal, yTotal  - minimumHeight, -10);
 
     }
 }


### PR DESCRIPTION
So that charge bars aren't ever blocked by player models.
Set to a value of 1.3 for now, might change in the future.